### PR TITLE
Update access mode options

### DIFF
--- a/server/routes/formData.ts
+++ b/server/routes/formData.ts
@@ -36,7 +36,7 @@ export default {
       kind: 'text',
     },
     options: [
-      { text: 'View only', value: 'READ', kind: 'option' },
+      { text: 'View only', value: 'READ_ONLY', kind: 'option' },
       { text: 'View and edit', value: 'READ_WRITE', kind: 'option' },
     ],
   },


### PR DESCRIPTION
Looks like the access mode enum for "read only" is different to the one in the handover service, updating here to fix the integration