### PR TITLE
Updates Lifestyle and associates upperbound to 6 from 10. 

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 NODE_ENV=dev && node_modules/.bin/lint-staged && npm run typecheck && npm test

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "record-build-info": "node ./bin/record-build-info",
     "lint": "eslint . --cache --max-warnings 0",
     "lint-fix": "eslint . --cache --max-warnings 0 --fix",
-    "typecheck": "tsc && tsc -p integration_tests",
+    "typecheck": "tsc",
     "test": "jest",
     "test:ci": "jest --runInBand",
     "security_audit": "npx audit-ci --config audit-ci.json",

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -57,7 +57,7 @@ const optionValues = (value: string, key: string, itemKey: string) => {
         upperBound = 10
         break
       case 'lifestyleAndAssociates':
-        upperBound = 10
+        upperBound = 6
         break
     }
     if (upperBound === undefined) {


### PR DESCRIPTION
Updates Husky script as required in https://github.com/typicode/husky/releases/tag/v9.0.1 and removes the tsc execution against non-existent `integration_tests` directory otherwise lint fails.