### PR TITLE
Fix 409 Conflict error in Dev and Test

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -60,7 +60,7 @@ export default function routes({ coordinatorService, handoverService }: Services
         },
       })
     } catch (e) {
-      if (e.status === 409) {
+      if (e.status === 409 || e.responseStatus === 409) {
         logger.info(`Association with PK ${oasysAssessmentPk} already exists, continuing`)
       } else {
         throw e


### PR DESCRIPTION
For some reason `e.status` becomes `e.responseStatus` when `NODE_ENV=production` ¯\\_(ツ)_/¯